### PR TITLE
Initial PackageConfig.json create

### DIFF
--- a/PackageConfig.json
+++ b/PackageConfig.json
@@ -1,0 +1,11 @@
+{
+    "Publisher"     : "Mozilla",
+    "ProductName"   : "Firefox",
+    "OldVersion"    : "82.0.3",
+    "VersionSource" : "Filename",
+    "Source"        : "https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang=en-US",
+    "DownloadPath"  : "C:\\Temp\\UMNAutoPackager\\Downloads",
+    "BuildPath"     : "C:\\Temp\\UMNAutoPackager\\Applications",
+    "BuildType"     : "Baseline",
+    "ConfigNotes"   : "General comments about this config file"
+}


### PR DESCRIPTION
This Resolves #17. Using Mozilla Firefox as an example.

The Firefox MSI does not have a dedicated version field to query, it will need to be parsed from the filename or another field. This is why the "VersionSource" key has a value of "Filename". The script reading this file to determine the version will need capability to parse the version from the downloaded filename.

There are scripts online that gather version info from the data inside the MSI itself - this may be a good option to utilize.