### PR TITLE
Create functions to simplify packages

### DIFF
--- a/UMN-AutoPackager/public/Copy-SupportFiles.ps1
+++ b/UMN-AutoPackager/public/Copy-SupportFiles.ps1
@@ -1,0 +1,67 @@
+function Copy-SupportFiles {
+    <#
+    .SYNOPSIS
+        Copies the support files to the target content locations.
+    .DESCRIPTION
+        Takes in an array list of content locations and copies the support files to each of them.  It also replaces the given variables in the support files if they are .ps1 files.
+    .PARAMETER ContentLocations
+        This is a list of the content locations stored in an arraylist.  This can be generated using Get-PkgContentLocations.
+    .PARAMETER ValuesToReplace
+        This is a list of the values to replace in the support files stored in a hashtable.
+    .PARAMETER SourcePath
+        The path to where the support files are located, this should always be (Split-Path -Path $MyInvocation.MyCommand.Path -Parent) unless otherwise required.
+    .EXAMPLE
+        PS C:\> Copy-SupportFiles -ContentLocations (Get-PkgContentLocations -PackageConfig $PackageConfig) -ValuesToReplace @{ "{currentVersion}" = "1.0.0" } -SourcePath (Split-Path -Path $MyInvocation.MyCommand.Path -Parent)
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [System.Collections.ArrayList]$ContentLocations,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [hashtable]$ValuesToReplace,
+
+        [Parameter(Mandatory = $false, Position = 2)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourcePath,
+
+        [Parameter(Mandatory = $true, Position = 3)]
+        [hashtable]$OtherFiles
+    )
+
+    foreach ($ContentLocation in $ContentLocations) {
+        Write-Information -MessageData "ContentLocation: $ContentLocation"
+        if (-not (Test-Path -Path $ContentLocation)) {
+            $null = New-Item -Path $ContentLocation -ItemType Directory -Force
+        }
+
+        Write-Information -MessageData "Checking for additional support files to copy from: $SourcePath\supportfiles"
+        if (Test-Path -Path "$SourcePath\supportfiles") {
+            Copy-Item -Path "$SourcePath\supportfiles\*" -Destination $ContentLocation -Force -PassThru
+        }
+
+        if (-not ($null -eq $OtherFiles)) {
+            foreach ($OtherFile in $OtherFiles.GetEnumerator()) {
+                Write-Information -MessageData "Copying $($OtherFile.Value) to $($ContentLocation)\$($OtherFile.Key)"
+                if (Test-Path -Path $OtherFile.Value) {
+                    Copy-Item -Path $OtherFile.Value -Destination "$($ContentLocation)\$($OtherFile.Key)" -Force
+                }
+            }
+        }
+
+        if (-not ($null -eq $ValuesToReplace)) {
+            # Update ps1 scripts with variables
+            Get-ChildItem -Path $ContentLocation -Filter "*.ps1" -Recurse | ForEach-Object {
+                Write-Information -MessageData "Updating file $_"
+                $Content = Get-Content -Path $_.FullName
+
+                foreach ($Value in $ValuesToReplace.GetEnumerator()) {
+                    Write-Information -MessageData "Replacing $($Value.Name) with $($Value.Value)"
+                    $Content = $Content.Replace($Value.Key, $Value.Value)
+                }
+
+                Set-Content -Path $_.FullName -Value $Content
+            }
+        }
+    }
+}

--- a/UMN-AutoPackager/public/Get-PkgContentLocations.ps1
+++ b/UMN-AutoPackager/public/Get-PkgContentLocations.ps1
@@ -1,0 +1,29 @@
+function Get-PkgContentLocations {
+    <#
+    .SYNOPSIS
+        Takes the package config and returns an arraylist of the content locations.
+    .DESCRIPTION
+        Takes the package config and returns an arraylist of the content locations.
+    .PARAMETER PackageConfig
+        The package config that is pulled in when invoking the autopackager.
+    .EXAMPLE
+        PS C:\> Get-PkgContentLocations -PackageConfig $PackageConfig
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true,
+            HelpMessage = "Input the values of the various PackageConfig.json files.")]
+        [psobject[]]$PackageConfig
+    )
+
+    [System.Collections.ArrayList]$ContentLocations = New-Object -TypeName System.Collections.ArrayList
+
+    foreach ($PackagingTarget in $PackageConfig.PackagingTargets) {
+        foreach ($DeploymentType in $PackagingTarget.DeploymentTypes) {
+            $ContentLocations.Add($DeploymentType.ContentLocation)
+            $DeploymentType.ReplaceVariable("{contentLocation}", $DeploymentType.ContentLocation)
+        }
+    }
+
+    return $ContentLocations
+}

--- a/UMN-AutoPackager/public/Invoke-AutoPackager.ps1
+++ b/UMN-AutoPackager/public/Invoke-AutoPackager.ps1
@@ -35,7 +35,7 @@ function Invoke-AutoPackager {
 
         if ($RecipeLocation.LocationType -eq "directory") {
             # Get all recipe directories
-            $RecipeDirs = Get-ChildItem -Path $($RecipeLocation.LocationUri.AbsolutePath) -Directory
+            $RecipeDirs = Get-ChildItem -Path $($RecipeLocation.LocationUri.AbsolutePath) -Directory -Exclude @(".*", "_*")
 
             # If directory empty, write error
             if ($RecipeDirs.Count -lt 1) {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ trigger:
       - 'beta'
       - 'alpha'
 
+pr: none
+
 variables:
   ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
     release: ''
@@ -100,8 +102,8 @@ steps:
     script: 'Get-Content -path $(Build.ArtifactStagingDirectory)/UMN-AutoPackager/UMN-AutoPackager.psd1'
     pwsh: true
 
-- task: NuGetAuthenticate@0
-  displayName: 'NuGet Authenticate'
+# - task: NuGetAuthenticate@0
+#   displayName: 'NuGet Authenticate'
 
 - pwsh: Publish-Module -Path "$(Build.ArtifactStagingDirectory)/UMN-AutoPackager" -NuGetApiKey $env:GalleryKey
   displayName: 'Publish NuGet Package'
@@ -122,13 +124,13 @@ steps:
 #      Publish-Module -Path "$(Build.ArtifactStagingDirectory)/UMN-AutoPackager" -Repository LocalPSRepo -NuGetApiKey "AzureDevOps" -Force
 #    pwsh: true
 
-- task: NugetCommand@2
-  displayName: 'Publish to NuGet Feed'
-  inputs:
-    command: 'push'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
-    publishVstsFeed: 'UMN-Internal'
-    allowPackageConflicts: false
+# - task: NugetCommand@2
+#   displayName: 'Publish to NuGet Feed'
+#   inputs:
+#     command: 'push'
+#     packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+#     publishVstsFeed: 'UMN-Internal'
+#     allowPackageConflicts: false
 
 - task: GitHubRelease@0
   displayName: 'Create GitHub Release'

--- a/build/quick_build_local.ps1
+++ b/build/quick_build_local.ps1
@@ -1,3 +1,8 @@
+param(
+    [switch]$PackageApp,
+    [switch]$CreateCollections,
+    [switch]$DeployApp
+)
 $Module = "UMN-AutoPackager"
 
 Push-Location $PSScriptRoot
@@ -6,11 +11,29 @@ Push-Location $PSScriptRoot
 Get-ChildItem -Path "$PSScriptRoot\..\output\$Module" | Remove-Item -Force -Recurse -Confirm:$false
 
 # Build Module to Output
-dotnet build $PSScriptRoot\..\src -o $PSScriptRoot\..\output\$Module\bin
+dotnet publish $PSScriptRoot\..\src -o $PSScriptRoot\..\output\$Module\bin
 Copy-Item "$PSScriptRoot\..\$Module\*" "$PSScriptRoot\..\output\$Module" -Recurse -Force
 
+$ModulePSD1 = Get-Content -Path "$PSScriptRoot\..\output\$Module\$Module.psd1"
+
+$UpdatedModule = $ModulePSD1.Replace("{version}", "0.0.1").Replace("'{prerelease}'", "''")
+
+Set-Content -Path "$PSScriptRoot\..\output\$Module\$Module.psd1" -Value $UpdatedModule
+
 $ArgList = @(
-    "-NoExit -Command ipmo .\UMN-AutoPackager.psd1"
+    "-NoExit -Command ipmo .\UMN-AutoPackager.psd1; Invoke-AutoPackager -GlobalConfig `$GlobalConfig -InformationAction Continue"
 )
+
+if ($PackageApp) {
+    $ArgList[0] = $ArgList[0] + " -PackageApp"
+}
+
+if ($CreateCollections) {
+    $ArgList[0] = $ArgList[0] + " -CreateCollections"
+}
+
+if ($DeployApp) {
+    $ArgList[0] = $ArgList[0] + " -DeployApp"
+}
 
 Start-Process -FilePath "pwsh.exe" -WorkingDirectory "$PSScriptRoot\..\output\$Module" -ArgumentList $ArgList


### PR DESCRIPTION
Created Copy-SupportFiles and Get-PkgContentLocations to help simplify package logic. This also includes some fixes to the build pipeline and build pipeline changes have been confirmed to work based on commit to the beta branch.  The changes to the module have been tested on all existing packages and confirmed to work.