### PR TITLE
Updated CDN

### DIFF
--- a/UMN-AutoPackager/public/Get-WinGetAllPackages.ps1
+++ b/UMN-AutoPackager/public/Get-WinGetAllPackages.ps1
@@ -54,7 +54,7 @@ left join pathparts on pathparts.rowid=manifest.pathpart
             $PathBuilder = $Parent
         } while ($null -ne $PathBuilder)
 
-        $AppManifestPath = "https://winget.azureedge.net/cache/" + $AppManifestPath
+        $AppManifestPath = "https://cdn.winget.microsoft.com/cache/" + $AppManifestPath
         $null = $OutputObject.Add((New-Object PSObject -Property ([ordered]@{
                         RowId        = $App.rowid
                         Id           = $App.id

--- a/UMN-AutoPackager/public/Update-WinGetPkgSource.ps1
+++ b/UMN-AutoPackager/public/Update-WinGetPkgSource.ps1
@@ -15,7 +15,7 @@ function Update-WinGetPkgSource {
         New-Item -Path $Path -Force -ItemType Directory
     }
 
-    $null = Invoke-WebRequest -Uri "https://winget.azureedge.net/cache/source.msix" -OutFile "$Path\source.msix" -PassThru
+    $null = Invoke-WebRequest -Uri "https://cdn.winget.microsoft.com/cache/source.msix" -OutFile "$Path\source.msix" -PassThru
     $null = Expand-Archive -Path "$Path\source.msix" -DestinationPath "$Path\source" -Force -PassThru
 
     return "$Path\source\Public\index.db"


### PR DESCRIPTION
moved from winget azureedge to cdn winget microsoft.

Corrects WinGet dependent applications that were no longer able to get yaml data
